### PR TITLE
INFC-17320 Add quotas

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,8 @@ the variables correctly:
     fi
 
     export OS_AUTH_URL=https://puppet.platform9.net/keystone/v3
+    export OS_NOVA_URL=https://puppet.platform9.net/nova/v2.1
+
     export OS_IDENTITY_API_VERSION=3
     export OS_REGION_NAME="Portland"
     export OS_USERNAME="$p9_user"

--- a/p9admin/cli/validators.py
+++ b/p9admin/cli/validators.py
@@ -23,9 +23,9 @@ def quota_name(quota_name):
     ]
 
     if quota_name not in quotas:
-        sys.exit('Quota "{}" invalid, try one of {}'.format(quota_name, quota_value))
+        sys.exit('Quota "{}" invalid, try one of {}'.format(quota_name, quotas))
 
 
 def quota_value(quota_name, quota_value):
     if int(quota_value) > 1000000:
-        sys.exit("'{}' seems a bit unreasonable, don't you think?".format(quota_value))
+        sys.exit("A setting of '{}' for {} seems a bit unreasonable, don't you think?".format(quota_value, quota_name))

--- a/p9admin/cli/validators.py
+++ b/p9admin/cli/validators.py
@@ -1,0 +1,31 @@
+import sys
+
+def quota_name(quota_name):
+    quotas = [
+        "instances",
+        "ram",
+        "cores",
+        "fixed_ips",
+        "floating_ips",
+        "injected_file_content_bytes",
+        "injected_file_path_bytes",
+        "injected_files",
+        "key_pairs",
+        "metadata_items",
+        "security_groups",
+        "security_group_rules",
+        "server_groups",
+        "server_group_members",
+        "networks",
+        "subnets",
+        "routers",
+        "root_gb",
+    ]
+
+    if quota_name not in quotas:
+        sys.exit('Quota "{}" invalid, try one of {}'.format(quota_name, quota_value))
+
+
+def quota_value(quota_name, quota_value):
+    if int(quota_value) > 1000000:
+        sys.exit("'{}' seems a bit unreasonable, don't you think?".format(quota_value))

--- a/p9admin/client.py
+++ b/p9admin/client.py
@@ -33,7 +33,7 @@ class OpenStackClient(object):
         if not project_name:
             project_name = os.environ["OS_PROJECT_NAME"]
 
-        print("Authenticating against project {}".format(project_name))
+        self.logger.info("Authenticating against project {}".format(project_name))
 
         if os.environ.get("OS_PROTOCOL", "password") == "SAML":
             self.logger.info('Authenticating as "%s" on project "%s" with SAML',
@@ -65,6 +65,7 @@ class OpenStackClient(object):
     def saml(self):
         return p9admin.SAML(self)
 
+    @memoize
     def api_token(self):
         """
         Get an API Token to make api requests.  This may be necessary for

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setuptools.setup(
         "click",
         "openstacksdk",
         "pf9-saml-auth",
+        "requests",
     ],
 
     include_package_data = True,


### PR DESCRIPTION
Woo-Hoo!  This code refactors a few things, but mostly adds the ability to change quotas on projects.  It does work, and I've tested it by raising everyone's core quota to 32.  

You'll notice that this PR interacts directly with the NOVA api, rather than using the existing openstacksdk code which would be simpler.  This is because as the time of this writing(as far as I can tell from the interwebs) the openstacksdk doesn't support adding quotas.  The question becomes.  do we hardcode the nova url or add it as another environment variable.  If we hardcode it, we'll probably want to have some kind of errorchecking as it won't be one of the ENV VARs that comes directly from the platform 9 UI(similary, I think the OS_USER_DOMAIN_ID env var is required, but it also is not in the platform 9 list of env vars)

