### PR TITLE
Grant groups of users access to projects directly

### DIFF
--- a/p9admin/cli/user.py
+++ b/p9admin/cli/user.py
@@ -24,11 +24,7 @@ def role_name(is_admin):
 def ensure_user(name, email):
     """Ensure that a local user is all set up"""
     client = p9admin.OpenStackClient()
-
-    user = p9admin.User(name, email)
-    project = p9admin.project.ensure_project(client, user.name)
-    client.ensure_user(user, default_project=project)
-    client.grant_project_access(project, user=user.user)
+    client.ensure_users([p9admin.User(name, email)])
 
 
 @user.command("ensure-ldap-users")
@@ -46,83 +42,7 @@ def ensure_ldap_users(filter, uid, password):
     client = p9admin.OpenStackClient()
 
     users = p9admin.user.get_ldap_users(filter, uid, password)
-    for user in users:
-        project = p9admin.project.ensure_project(client, user.name)
-        client.ensure_user(user, default_project=project)
-        client.grant_project_access(project, user=user.user)
-
-
-@user.command("ensure-group")
-@click.argument("name")
-@click.argument("emails", nargs=-1)
-@click.option("--keep-others/--remove-others", default=True)
-def ensure_group(name, emails, keep_others):
-    """Ensure that a group exists"""
-
-    client = p9admin.OpenStackClient()
-    group = client.ensure_group(name)
-
-    users = []
-    bad_emails = []
-    for email in emails:
-        user = client.find_user(email)
-        if user is None:
-            bad_emails.append(email)
-        else:
-            users.append(user)
-
-    if bad_emails:
-        sys.exit("Could not find the following users: {}".format(
-            ", ".join(bad_emails)))
-
-    client.ensure_group_members(group, users, keep_others=keep_others)
-
-
-@user.command("ensure-ldap-group")
-@click.argument("name", metavar="GROUP-CN")
-@click.option("--keep-others/--remove-others", default=True)
-@click.option("--uid", "-u", envvar='puppetpass_username')
-@click.option("--password", "-p",
-              prompt='puppetpass_password' not in os.environ,
-              hide_input=True,
-              default=os.environ.get('puppetpass_password', None))
-def ensure_ldap_group(name, keep_others, uid, password):
-    """Ensure that a group exists based on an LDAP group"""
-
-    if not uid:
-        sys.exit("You must specify --uid USER to connect to LDAP")
-
-    p9Users = p9admin.user.get_ldap_group_users(name, uid, password)
-
-    client = p9admin.OpenStackClient()
-    users = p9admin.user.load_users(p9Users, client)
-
-    group = client.ensure_group(name)
-    client.ensure_group_members(group, users, keep_others=keep_others)
-
-
-@user.command("ensure-ldap-group-filter")
-@click.argument("name")
-@click.argument("filter", metavar="USER-FILTER")
-@click.option("--keep-others/--remove-others", default=True)
-@click.option("--uid", "-u", envvar='puppetpass_username')
-@click.option("--password", "-p",
-              prompt='puppetpass_password' not in os.environ,
-              hide_input=True,
-              default=os.environ.get('puppetpass_password', None))
-def ensure_ldap_group_filter(name, filter, keep_others, uid, password):
-    """Ensure that a group exists based on an LDAP filter"""
-
-    if not uid:
-        sys.exit("You must specify --uid USER to connect to LDAP")
-
-    p9Users = p9admin.user.get_ldap_users(filter, uid, password)
-
-    client = p9admin.OpenStackClient()
-    users = p9admin.user.load_users(p9Users, client)
-
-    group = client.ensure_group(name)
-    client.ensure_group_members(group, users, keep_others=keep_others)
+    client.ensure_users(users)
 
 
 @user.command("grant-user")
@@ -155,36 +75,3 @@ def revoke_user(email, project, admin):
 
     client.revoke_project_access(
         client.find_project(project), user=user, role_name=role_name(admin))
-
-
-@user.command("grant-group")
-@click.argument("name")
-@click.argument("project")
-@click.option("--admin/--member", default=False)
-def grant_group(name, project, admin):
-    """Grant a group access to a project"""
-    client = p9admin.OpenStackClient()
-
-    group = client.find_group(name)
-    if not group:
-        sys.exit('Group "{}" not found'.format(name))
-
-    client.grant_project_access(
-        client.find_project(project), group=group, role_name=role_name(admin))
-
-
-@user.command("revoke-group")
-@click.argument("name")
-@click.argument("project")
-@click.option("--admin/--member", default=False)
-def revoke_group(name, project, admin):
-    """Revoke a group's access to a project"""
-
-    client = p9admin.OpenStackClient()
-
-    group = client.find_group(name)
-    if not group:
-        sys.exit('Group "{}" not found'.format(name))
-
-    client.revoke_project_access(
-        client.find_project(project), group=group, role_name=role_name(admin))


### PR DESCRIPTION
Previously we created a group object in OpenStack. Platform9 does not seem to support group objects correctly (users were not able to access their shared projects), and it doesn't show groups in the UI.

This switches to granting users access to projects directly.