### PR TITLE
(INFC-17619) Don't create port when creating router

### DIFF
--- a/p9admin/cli/project.py
+++ b/p9admin/cli/project.py
@@ -13,6 +13,39 @@ def project():
     """Manage projects"""
     pass
 
+@project.command()
+def portlist():
+    """
+    List all projects with reserved_dhcp_port stats
+
+    device_id=reserved_dhcp_port is bad since they make DHCP include a bad
+    nameserver in its response.
+    """
+    client = p9admin.OpenStackClient()
+    for network in client.openstack().network.networks(name="network1"):
+        reserved = 0
+        all = 0
+        for port in client.openstack().network.ports(network_id=network.id):
+            if port.device_id == "reserved_dhcp_port":
+                reserved += 1
+            all += 1
+        if reserved != 1:
+            all = str(all) + " **"
+        print("{} {}/{}".format(network.id, reserved, all))
+
+@project.command()
+def cleanports():
+    """
+    List all projects with reserved_dhcp_port stats
+
+    device_id=reserved_dhcp_port is bad since they make DHCP include a bad
+    nameserver in its response.
+    """
+    client = p9admin.OpenStackClient()
+    for port in client.openstack().network.ports(device_id="reserved_dhcp_port"):
+        print("Deleting port {} on network {}".format(port.id, port.network_id))
+        client.openstack().network.delete_port(port)
+
 
 @project.command()
 @click.argument("name")

--- a/p9admin/cli/project.py
+++ b/p9admin/cli/project.py
@@ -13,39 +13,6 @@ def project():
     """Manage projects"""
     pass
 
-@project.command()
-def portlist():
-    """
-    List all projects with reserved_dhcp_port stats
-
-    device_id=reserved_dhcp_port is bad since they make DHCP include a bad
-    nameserver in its response.
-    """
-    client = p9admin.OpenStackClient()
-    for network in client.openstack().network.networks(name="network1"):
-        reserved = 0
-        all = 0
-        for port in client.openstack().network.ports(network_id=network.id):
-            if port.device_id == "reserved_dhcp_port":
-                reserved += 1
-            all += 1
-        if reserved != 1:
-            all = str(all) + " **"
-        print("{} {}/{}".format(network.id, reserved, all))
-
-@project.command()
-def cleanports():
-    """
-    List all projects with reserved_dhcp_port stats
-
-    device_id=reserved_dhcp_port is bad since they make DHCP include a bad
-    nameserver in its response.
-    """
-    client = p9admin.OpenStackClient()
-    for port in client.openstack().network.ports(device_id="reserved_dhcp_port"):
-        print("Deleting port {} on network {}".format(port.id, port.network_id))
-        client.openstack().network.delete_port(port)
-
 
 @project.command()
 @click.argument("name")

--- a/p9admin/client.py
+++ b/p9admin/client.py
@@ -314,19 +314,6 @@ class OpenStackClient(object):
             description="Default router",
             external_gateway_info={"network_id": self.external_network().id})
         self.logger.info('Created router "%s" [%s]', router.name, router.id)
-
-        port = self.openstack().network.create_port(
-            project_id=project.id,
-            network_id=network.id,
-            fixed_ips=[
-                {"subnet_id": subnet.id, "ip_address": subnet.gateway_ip}
-            ])
-        self.logger.info("Created port [%s] on tenant subnet", port.id)
-
-        self.openstack().network.add_interface_to_router(
-            router, subnet_id=subnet.id, port_id=port.id)
-        self.logger.info("Added port to router")
-
         return router
 
     def find_security_group(self, project, name):


### PR DESCRIPTION
The ports are automatically created, and this code was producing an extra DNS server in DHCP responses, but the DNS server didn't actually exist.