### PR TITLE
(INFC-18554) revert PR #13

### DIFF
--- a/p9admin/client.py
+++ b/p9admin/client.py
@@ -320,6 +320,19 @@ class OpenStackClient(object):
             description="Default router",
             external_gateway_info={"network_id": self.external_network().id})
         self.logger.info('Created router "%s" [%s]', router.name, router.id)
+
+        port = self.openstack().network.create_port(
+            project_id=project.id,
+            network_id=network.id,
+            fixed_ips=[
+                {"subnet_id": subnet.id, "ip_address": subnet.gateway_ip}
+            ])
+        self.logger.info("Created port [%s] on tenant subnet", port.id)
+
+        self.openstack().network.add_interface_to_router(
+            router, subnet_id=subnet.id, port_id=port.id)
+        self.logger.info("Added port to router")
+
         return router
 
     def find_security_group(self, project, name):


### PR DESCRIPTION
I'm not sure what changed in P9, but any new users provisioned cannot attach a floating IP to an instance without manually adding a new interface to router0 on network1: subnet0.  Several users have reported this and I've reproduced it myself.

We used to add the router interface during provisioning, and this commit would add it back in.

After testing with this change back in, I'm not able to reproduce the issue described in [INFC-17619](https://tickets.puppetlabs.com/browse/INFC-17619).  For instance, my `/etc/resolve.conf` doesn't include the problematic IP:

```
; generated by /usr/sbin/dhclient-script
search platform9.puppet.net puppetdebug.vlan
nameserver 192.168.0.2
nameserver 192.168.0.3
```