### PR TITLE
(maint) Fix role find call

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,8 @@
-# This will cause InfraCore to be assigned review of any opened PRs against
+# This will cause DIO to be assigned review of any opened PRs against
 # the branches containing this file.
 # See https://help.github.com/en/articles/about-code-owners for info on how to
 # take ownership of parts of the code base that should be reviewed by another
 # team.
 
-*  @puppetlabs/infracore
+*  @puppetlabs/dio
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Everybody in the company should already have a user. However, when somebody
 joins the company you'll need to create a new account for them:
 
 ```
-p9-admin -v user ensure-ldap-users uid=happy.noob
+p9-admin -v user ensure-ldap-users uid=happy.noob --uid=my_ldap_uid
 ```
 
 That will load the user's information from LDAP, then create a user and project
@@ -120,8 +120,8 @@ p9-admin
 
 ## Using via Docker
 
-If you wish to use p9-admin via `docker run` you can do so by wither building
-the contaner locally or by pulling it from our internal registry like so:
+If you wish to use p9-admin via `docker run` you can do so by either building
+the container locally or by pulling it from our internal registry like so:
 
 ```
 source creds-platform9-service.sh

--- a/p9admin/client.py
+++ b/p9admin/client.py
@@ -89,7 +89,7 @@ class OpenStackClient(object):
 
     @memoize
     def role(self, name):
-        return list(self.keystone().roles.find(name=name))
+        return self.keystone().roles.find(name=name)
 
     @memoize
     def service_project(self):


### PR DESCRIPTION
This PR closes #25, updates the `CODEOWNERS` file to DIO, and makes a few small edits to the `README`.

Output of adding a new user with the changes made:
<img width="805" alt="Screen Shot 2020-05-21 at 7 44 45 PM" src="https://user-images.githubusercontent.com/38337779/82683922-a4fcf700-9c06-11ea-8a69-69e908eea4ae.png">
 
- More on this error: the call to the `list()` was removed because the user object is a non-iterable (which is a requirement of this function) and was unnecessary since the user object's data members are directly accessible so converting it to a list was not required.